### PR TITLE
Hijax XHR proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Smuggler XHR Proxy
+# Hijax XHR Proxy

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "smuggler",
+    "name": "hijax",
     "version": "0.0.1",
     "dependencies": {
         "connect": "2.3.4",


### PR DESCRIPTION
Hijax XHR proxy

Status: **Opened for visibility**

Reviewers: @jansepar @scalvert @tedtate @kbingman @noahadams @MikeKlemarewski 
## Introduction
- The XHR proxy overwrites a couple of key XMLHttpRequest methods with a custom proxied version. This allows hooking on to AJAX send/receive methods independently of the library used.
- Assumes that the library uses the XMLHttpRequest as the transport. Proxies the xhr instance **onreadystatechanged** method to proxy code. If not found, attaches to the xhr **readystatechange** event. This is needed for jQuery, for example, which sets the **onreadystatechange** handler **after** it launches a send request.
- Provides three events: **.beforeSend**, **.receive** and **.complete**. All three have the XHR instance as their only argument. We could possibly provide the data (responseText) directly, but then we'd need to account for MIME types. For example, jQuery responds to JSON, Script, Text, XML, etc. data differently.
## How to test-drive this PR
- `grunt serve` and go to localhost:8888/example and check your console. You'll note that the jQuery AJAX event has been intercepted
- (Optional) Try swapping out jQuery for another library to ensure XHR is still intercepted
## Research resources
- https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest
- http://api.jquery.com/jquery.ajax/
