### PR TITLE
Adds remove listener function to hijax.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,14 @@
+0.2.0
+    - Fixed error in integration test
+    - Fixed circle.yml to run tests correctly
+    - Added removeListener functions to hijax and hijacker
+    - Added tests for add/removeListener hijacker functions
+0.1.3
+    - Updated requirejs
+    - Refactored examples
+0.1.2
+    - Fixed a bug in jQuery 1.3.2 adapter
+    - Fixed a bug in Hijacker when content type headers weren't available
+    - Some example refactoring
+0.1.1
+    - Initial release

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,7 @@ machine:
   node:
     version: 0.10.21
 
-dependencies:
-    override:
-        - npm install
 
 test:
     override:
-        - ./node_modules/mocha/bin/mocha --timeout 20000
+        - grunt test

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   node:
     version: 0.10.21
 
+dependencies:
+    override:
+        - npm install
+        - bower install
 
 test:
     override:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hijax",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "dependencies": {
     "connect": "2.19.6",
     "grunt": "0.4.2",

--- a/src/hijacker.js
+++ b/src/hijacker.js
@@ -171,5 +171,27 @@
         this.callbacks[method].push(cb);
     };
 
+    // Removes the callback specified, or all callbacks for the method if no callback is given
+    Hijacker.prototype.removeListener = function(method, cb) {
+        var listeners;
+        if (!(method in this.callbacks)) {
+            throw (method + ' listener does not exist!');
+        }
+
+        listeners = this.callbacks[method];
+
+        if (cb) {
+            var foundAt = listeners.indexOf(cb);
+            if (foundAt < 0) {
+                throw (cb + ' callback does not exist!');
+            }
+            listeners = listeners.slice(0, foundAt).concat(listeners.slice(foundAt + 1));
+        } else {
+            listeners = [];
+        }
+
+        this.callbacks[method] = listeners;
+    };
+
     return Hijacker;
 }));

--- a/src/hijax.js
+++ b/src/hijax.js
@@ -97,6 +97,15 @@
         this.proxies[name].addListener(method, callback);
     };
 
+    Hijax.prototype.removeListener = function(name, method, callback) {
+        // Getter
+        if (!(name in this.proxies)) {
+            throw name + ' proxy does not exist!';
+        }
+
+        this.proxies[name].removeListener(method, callback);
+    };
+
     // Dispatch current event to all listeners
     Hijax.prototype.dispatch = function(event, xhr, callback) {
         var proxies = this.proxies;

--- a/tests/integration/jquery-1.3.2.js
+++ b/tests/integration/jquery-1.3.2.js
@@ -5,7 +5,7 @@ function(Hijax, jQuery, adapter) {
         var hijax = new Hijax(adapter);
 
         hijax
-            .set('home', '/example/response.json', {
+            .set('home', '/examples/response.json', {
                 receive: function() {
                     foo = 'baz';
                 },
@@ -17,7 +17,7 @@ function(Hijax, jQuery, adapter) {
         it('proxies the AJAX request', function(done) {
             jQuery
                 .ajax({
-                    url: '/example/response.json',
+                    url: '/examples/response.json',
                     type: 'GET',
                     success: function(data) {
                         // Should have a value thanks to the proxy

--- a/tests/integration/jquery-2.1.1.js
+++ b/tests/integration/jquery-2.1.1.js
@@ -5,7 +5,7 @@ function(Hijax, jQuery) {
         var hijax = new Hijax();
 
         hijax
-            .set('home', '/example/response.json', {
+            .set('home', '/examples/response.json', {
                 receive: function(data, xhr) {
                     foo = 'baz';
                 },
@@ -17,7 +17,7 @@ function(Hijax, jQuery) {
         it('proxies the AJAX request', function(done) {
             jQuery
                 .ajax({
-                    url: '/example/response.json',
+                    url: '/examples/response.json',
                     type: 'GET',
                     success: function(data, status, xhr) {
                         // Should have a value thanks to the proxy

--- a/tests/testRunner.js
+++ b/tests/testRunner.js
@@ -7,6 +7,7 @@ require(['config'], function(){
         var tests = [
             'tests/unit/hijax',
             'tests/unit/hijacker',
+            'tests/unit/hijackerListeners',
 
             'tests/integration/jquery-1.3.2',
             'tests/integration/jquery-2.1.1'

--- a/tests/unit/hijackerListeners.js
+++ b/tests/unit/hijackerListeners.js
@@ -1,0 +1,60 @@
+define(['hijacker'],
+function(Hijacker) {
+    var callbackOne = function() {
+        return 1;
+    };
+    var callbackTwo = function() {
+        return 2;
+    };
+    var hijacker;
+
+
+    describe('Hijacker listeners', function() {
+        beforeEach(function() {
+            hijacker = new Hijacker('test', '/', {});
+        });
+
+        afterEach(function() {
+            if (hijacker) {
+                hijacker = null;
+            }
+        });
+
+        it('adds a listener callback', function() {
+            hijacker.addListener('receive', callbackOne);
+
+            assert.include(hijacker.callbacks['receive'], callbackOne, 'A callback has been added.');
+        });
+
+        it('removes only one callback when passed a valid callback', function() {
+            hijacker.addListener('receive', callbackOne);
+            hijacker.addListener('receive', callbackTwo);
+
+
+            hijacker.removeListener('receive', callbackOne);
+
+            assert.deepEqual(hijacker.callbacks['receive'], [callbackTwo], 'One of two callbacks have been removed');
+        });
+
+        it('removes all callbacks when passed no callbacks', function() {
+            hijacker.addListener('receive', callbackOne);
+            hijacker.addListener('receive', callbackTwo);
+
+
+            hijacker.removeListener('receive');
+
+            assert.deepEqual(hijacker.callbacks['receive'], [], 'All callbacks have been removed');
+        });
+
+        it('removes no callbacks when passed invalid callback', function() {
+            hijacker.addListener('receive', callbackOne);
+            hijacker.addListener('receive', callbackTwo);
+
+            try {
+                hijacker.removeListener('receive', function() { return; });
+            } catch (e) {
+                assert.deepEqual(hijacker.callbacks['receive'], [callbackOne, callbackTwo], 'No callbacks have been removed.');
+            }
+        })
+    });
+});


### PR DESCRIPTION
Added the ability to remove a specific callback or all callbacks from a proxied method. 

Status: **Opened for visibility**
Reviewers: **@donnielrt @scalvert**
JIRA: **N/A**

## Changes
- Fixed error in integration test
- Updated circle.yml to run tests
- Added removeListener functions to hijax and hijacker
- Added tests for add/removeListener hijacker functions.

## Test Drive this PR
- Checkout this branch
-  `grunt test`