### PR TITLE
Cut release 0.3.0 for NPM publishing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,3 @@
-0.3.0
-    - Publish on NPM
 0.2.0
     - Fixed error in integration test
     - Fixed circle.yml to run tests correctly

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.3.0
+    - Publish on NPM
 0.2.0
     - Fixed error in integration test
     - Fixed circle.yml to run tests correctly

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+he MIT License (MIT)
+
+Copyright (c) 2013 Mobify Research &amp; Development Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-he MIT License (MIT)
+The MIT License (MIT)
 
 Copyright (c) 2013 Mobify Research &amp; Development Inc.
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,42 @@
 {
   "name": "hijax",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "dependencies": {
     "connect": "2.19.6",
     "grunt": "0.4.2",
-    "mocha": "1.14.0",
-    "grunt-mocha-phantomjs": "~0.3.2",
-    "chai": "1.9.0",
     "grunt-contrib-jshint": "0.10.0",
     "jshint": "2.5.0",
     "grunt-jscs-checker": "0.4.1",
     "mobify-code-style": "0.0.3",
     "grunt-contrib-connect": "~0.8.0",
     "grunt-requirejs": "^0.4.2"
-  }
+  },
+  "description": "[![Bower version](https://badge.fury.io/bo/hijax.svg)](http://badge.fury.io/bo/hijax)",
+  "main": "Gruntfile.js",
+  "directories": {
+    "example": "examples",
+    "test": "tests"
+  },
+  "devDependencies": {
+    "mocha": "1.14.0",
+    "grunt-mocha-phantomjs": "~0.3.2",
+    "chai": "1.9.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mobify/hijax.git"
+  },
+  "keywords": [
+    "hijax",
+    "ajax"
+  ],
+  "author": "Mobify",
+  "license": "SEE LICENSE IN LICENSE",
+  "bugs": {
+    "url": "https://github.com/mobify/hijax/issues"
+  },
+  "homepage": "https://github.com/mobify/hijax#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hijax",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "dependencies": {
     "connect": "2.19.6",
     "grunt": "0.4.2",


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @jansepar @mikenikles @fractaltheory 

## Changes
- Prep release for publishing Hijax on NPM

## Todos:
- [x] +1
- [ ] Post Merge: Tag, release, and publish on NPM

### Feedback:
_none so far_

## How to Test
- Review changes to `package.json`
- Review newly added `LICENSE`