### PR TITLE
Singleton Hijax

### DIFF
--- a/src/hijax.js
+++ b/src/hijax.js
@@ -50,6 +50,12 @@
     };
 
     function Hijax(adapter) {
+        if (Hijax.prototype._instance) {
+            return Hijax.prototype._instance;
+        }
+
+        Hijax.prototype._instance = this;
+
         this.proxies = {};
         this.adapter = adapter;
 


### PR DESCRIPTION
**Hijax should be a singleton**

Hijax overrides the native **window.XMLHttpRequest.prototype.open** and **window.XMLHttpRequest.prototype.send**

When a Hijax object is initialized the first time, the native open and send function will be replaced by the Hijax proxy functions.

When a second initialization of the Hijax object happens, we end up with a nested proxy functions.

Tho the impact of this is only limit to how many times Hijax object is created, we should fix this.

### Explanation

1. `Hijax.prototype.proxyXHREvents` redefines the new open and send functions and calls `Hijax.prototype.proxyXhrMethod`
2. `Hijax.prototype.proxyXhrMethod` wraps the native method with the proxy function to extend the ability to have a before and after call functions
3. `Hijax.prototype.setXHRMethod` overrides the native method with the new proxy function

```
    Hijax.prototype.getXHRMethod = function(method) {
        return window.XMLHttpRequest.prototype[method];
    };

    Hijax.prototype.setXHRMethod = function(method, value) {
        window.XMLHttpRequest.prototype[method] = value;
    };

    Hijax.prototype.proxyXhrMethod = function(method, before, after) {
        var proxy = proxyFunction(this.getXHRMethod(method), before, after);
        this.setXHRMethod(method, proxy);
    };
```

As you can see, the second time Hijax object is created, it will override the native method that we already override.